### PR TITLE
feat: add minimal microkernel boot skeleton

### DIFF
--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -1,0 +1,64 @@
+; boot.asm - 16-bit boot sector for AikyaOS
+BITS 16
+ORG 0x7C00
+
+start:
+    cli
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7C00
+
+    mov [boot_drive], dl
+
+    ; Load kernel (assumes <20 sectors)
+    mov bx, 0x1000        ; load address
+    mov ah, 0x02          ; BIOS read
+    mov al, 20            ; number of sectors
+    mov ch, 0
+    mov cl, 2             ; start sector
+    mov dh, 0
+    mov dl, [boot_drive]
+    int 0x13
+    jc disk_error
+
+; GDT for protected mode
+
+gdt_start:
+gdt_null:   dq 0
+gdt_code:   dq 0x00CF9A000000FFFF
+gdt_data:   dq 0x00CF92000000FFFF
+gdt_end:
+
+gdt_descriptor:
+    dw gdt_end - gdt_start - 1
+    dd gdt_start
+
+    ; Enter protected mode
+    lgdt [gdt_descriptor]
+    mov eax, cr0
+    or eax, 1
+    mov cr0, eax
+    jmp 0x08:protected_mode
+
+[BITS 32]
+protected_mode:
+    mov ax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+    mov esp, 0x90000
+
+    jmp 0x08:0x1000 ; jump to kernel
+
+disk_error:
+    hlt
+    jmp disk_error
+
+boot_drive: db 0
+
+times 510-($-$$) db 0
+dw 0xAA55

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,0 +1,42 @@
+CROSS ?= i686-elf-
+CC = $(CROSS)gcc
+LD = $(CROSS)ld
+OBJCOPY = $(CROSS)objcopy
+AS = nasm
+
+CFLAGS = -ffreestanding -fno-pic -fno-stack-protector -m32 -nostdlib -Wall -Wextra
+LDFLAGS = -T linker.ld -nostdlib -m elf_i386
+
+all: aikyaos.iso
+
+boot.bin: ../boot/boot.asm
+	$(AS) -f bin $< -o $@
+
+kernel.o: ../kernel/kernel.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+entry.o: ../kernel/entry.asm
+	$(AS) -f elf32 $< -o $@
+
+kernel.bin: kernel.o entry.o
+	$(LD) $(LDFLAGS) entry.o kernel.o -o kernel.elf
+	$(OBJCOPY) -O binary kernel.elf $@
+
+os-image.bin: boot.bin kernel.bin
+	cat $^ > $@
+
+isodir:
+	mkdir -p isodir
+	cp os-image.bin isodir/boot.bin
+
+aikyaos.iso: os-image.bin isodir
+	xorriso -as mkisofs -R -b boot.bin -no-emul-boot -o $@ isodir
+
+clean:
+	rm -f *.o *.bin *.elf aikyaos.iso
+	rm -rf isodir
+
+run: all
+	qemu-system-i386 -cdrom aikyaos.iso
+
+.PHONY: all clean run

--- a/build/linker.ld
+++ b/build/linker.ld
@@ -1,0 +1,9 @@
+ENTRY(_start)
+SECTIONS
+{
+    . = 0x1000;
+    .text : { *(.text*) }
+    .rodata : { *(.rodata*) }
+    .data : { *(.data*) }
+    .bss : { *(.bss*) *(COMMON) }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,33 @@
+# AikyaOS Phase 1 Architecture
+
+AikyaOS begins as a minimal hybrid microkernel. Only the core services – task
+scheduling, basic interrupt dispatch and a text console – live inside the
+kernel. Device drivers and system servers will run in user mode in later
+phases and communicate through an IPC mechanism.
+
+## Boot Flow
+
+1. The BIOS loads the 512 byte boot sector (`boot/boot.asm`) to 0x7C00.
+2. The boot sector loads the kernel image located in the following sectors
+   into memory at 0x1000 and switches the CPU to 32‑bit protected mode.
+3. Control jumps to the kernel entry point where the C runtime starts.
+4. The kernel sets up its own GDT and an empty IDT, clears the screen and
+   prints a boot message.
+
+## Memory Map
+
+```
+0x00000000 - 0x000003FF : Real mode IVT
+0x00007C00 - 0x00007DFF : Boot sector
+0x00001000 - 0x00008FFF : Loaded kernel image
+0x000B8000 - 0x000B8FFF : VGA text buffer
+```
+
+The kernel currently runs in identity mapped low memory. A higher half
+layout and paging will be introduced in later phases.
+
+## Future Work
+
+- Scheduler, IPC and user mode drivers.
+- Paging and virtual memory separation.
+- Filesystem and user programs.

--- a/kernel/entry.asm
+++ b/kernel/entry.asm
@@ -1,0 +1,12 @@
+; entry.asm - 32-bit kernel entry
+BITS 32
+GLOBAL _start
+EXTERN kmain
+
+_start:
+    cli
+    mov esp, 0x9FB00
+    call kmain
+.hang:
+    hlt
+    jmp .hang

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -1,0 +1,114 @@
+#include <stdint.h>
+
+typedef uint32_t size_t;
+
+#define VGA_ADDR 0xB8000
+#define WHITE_ON_BLACK 0x0F
+
+static uint16_t *const vga_buffer = (uint16_t *)VGA_ADDR;
+
+static void kprint(const char *s) {
+    size_t i = 0;
+    while (s[i]) {
+        vga_buffer[i] = (uint16_t)s[i] | (WHITE_ON_BLACK << 8);
+        i++;
+    }
+}
+
+struct gdt_entry {
+    uint16_t limit_low;
+    uint16_t base_low;
+    uint8_t  base_mid;
+    uint8_t  access;
+    uint8_t  gran;
+    uint8_t  base_high;
+} __attribute__((packed));
+
+struct gdt_ptr {
+    uint16_t limit;
+    uint32_t base;
+} __attribute__((packed));
+
+static struct gdt_entry gdt[3];
+static struct gdt_ptr gp;
+
+static void gdt_set_gate(int num, uint32_t base, uint32_t limit,
+                         uint8_t access, uint8_t gran) {
+    gdt[num].base_low = base & 0xFFFF;
+    gdt[num].base_mid = (base >> 16) & 0xFF;
+    gdt[num].base_high = (base >> 24) & 0xFF;
+
+    gdt[num].limit_low = limit & 0xFFFF;
+    gdt[num].gran = ((limit >> 16) & 0x0F) | (gran & 0xF0);
+    gdt[num].access = access;
+}
+
+static inline void lgdt(struct gdt_ptr *g) {
+    __asm__ volatile("lgdt (%0)" : : "r"(g));
+}
+
+static inline void lidt(void *i) {
+    __asm__ volatile("lidt (%0)" : : "r"(i));
+}
+
+struct idt_entry {
+    uint16_t base_low;
+    uint16_t sel;
+    uint8_t  always0;
+    uint8_t  flags;
+    uint16_t base_high;
+} __attribute__((packed));
+
+struct idt_ptr {
+    uint16_t limit;
+    uint32_t base;
+} __attribute__((packed));
+
+static struct idt_entry idt[256];
+static struct idt_ptr idtp;
+
+static void idt_install(void) {
+    idtp.limit = sizeof(struct idt_entry) * 256 - 1;
+    idtp.base = (uint32_t)&idt;
+
+    for (int i = 0; i < 256; i++) {
+        idt[i].base_low = 0;
+        idt[i].sel = 0;
+        idt[i].always0 = 0;
+        idt[i].flags = 0;
+        idt[i].base_high = 0;
+    }
+
+    lidt(&idtp);
+}
+
+static void gdt_install(void) {
+    gp.limit = sizeof(gdt) - 1;
+    gp.base = (uint32_t)&gdt;
+
+    gdt_set_gate(0, 0, 0, 0, 0);
+    gdt_set_gate(1, 0, 0xFFFFFFFF, 0x9A, 0xCF);
+    gdt_set_gate(2, 0, 0xFFFFFFFF, 0x92, 0xCF);
+
+    lgdt(&gp);
+
+    __asm__ volatile(
+        "mov $0x10, %%ax\n"
+        "mov %%ax, %%ds\n"
+        "mov %%ax, %%es\n"
+        "mov %%ax, %%fs\n"
+        "mov %%ax, %%gs\n"
+        "mov %%ax, %%ss\n"
+        "ljmp $0x08, $.flush\n"
+        ".flush:\n"
+        : : : "ax");
+}
+
+void kmain(void) {
+    gdt_install();
+    idt_install();
+    kprint("AikyaOS Phase1");
+    for (;;) {
+        __asm__ volatile("hlt");
+    }
+}


### PR DESCRIPTION
## Summary
- introduce 16-bit bootloader that loads kernel and switches to protected mode
- provide 32-bit kernel with GDT/IDT initialization and simple text console
- add build system and linker script to produce bootable image

## Testing
- `make -C build clean`
- `make -C build CROSS=` *(fails: `xorriso` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68909b64f2708330aaf17f7a5c96abd1