### PR TITLE
feat: add phase 2 protected-mode kernel bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+CROSS ?= i686-elf-
+CC = $(CROSS)gcc
+LD = $(CROSS)ld
+OBJCOPY = $(CROSS)objcopy
+AS = nasm
+
+CFLAGS = -ffreestanding -fno-pic -fno-stack-protector -m32 -nostdlib -Wall -Wextra
+LDFLAGS = -T linker.ld -nostdlib -m elf_i386
+
+BOOT_BIN = boot.bin
+KERNEL_BIN = kernel.bin
+IMG = aikyaos.img
+
+all: $(IMG)
+
+$(BOOT_BIN): boot/boot.asm
+	$(AS) -f bin $< -o $@
+
+kernel_entry.o: kernel/entry.asm
+	$(AS) -f elf32 $< -o $@
+
+kernel.o: kernel/kernel.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(KERNEL_BIN): kernel_entry.o kernel.o
+	$(LD) $(LDFLAGS) -o kernel.elf kernel_entry.o kernel.o
+	$(OBJCOPY) -O binary kernel.elf $@
+
+$(IMG): $(BOOT_BIN) $(KERNEL_BIN)
+	cat $(BOOT_BIN) $(KERNEL_BIN) > $@
+
+run-img: $(IMG)
+	qemu-system-i386 -drive format=raw,file=$(IMG)
+
+clean:
+	rm -f $(BOOT_BIN) kernel_entry.o kernel.o kernel.elf $(KERNEL_BIN) $(IMG)
+
+.PHONY: all clean run-img

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CC = $(CROSS)gcc
 LD = $(CROSS)ld
 OBJCOPY = $(CROSS)objcopy
 AS = nasm
+.RECIPEPREFIX := >
 
 CFLAGS = -ffreestanding -fno-pic -fno-stack-protector -m32 -nostdlib -Wall -Wextra
 LDFLAGS = -T linker.ld -nostdlib -m elf_i386
@@ -13,26 +14,29 @@ IMG = aikyaos.img
 
 all: $(IMG)
 
-$(BOOT_BIN): boot/boot.asm
-	$(AS) -f bin $< -o $@
-
 kernel_entry.o: kernel/entry.asm
-	$(AS) -f elf32 $< -o $@
+>$(AS) -f elf32 $< -o $@
 
 kernel.o: kernel/kernel.c
-	$(CC) $(CFLAGS) -c $< -o $@
+>$(CC) $(CFLAGS) -c $< -o $@
 
 $(KERNEL_BIN): kernel_entry.o kernel.o
-	$(LD) $(LDFLAGS) -o kernel.elf kernel_entry.o kernel.o
-	$(OBJCOPY) -O binary kernel.elf $@
+>$(LD) $(LDFLAGS) -o kernel.elf kernel_entry.o kernel.o
+>$(OBJCOPY) -O binary kernel.elf $@
+
+$(BOOT_BIN): boot/boot.asm $(KERNEL_BIN)
+>set -e; \
+>KS=$$(stat -c%s $(KERNEL_BIN)); \
+>SECT=$$(( (KS + 511) / 512 )); \
+>$(AS) -f bin -DKERNEL_SECTORS=$$SECT $< -o $@
 
 $(IMG): $(BOOT_BIN) $(KERNEL_BIN)
-	cat $(BOOT_BIN) $(KERNEL_BIN) > $@
+>cat $(BOOT_BIN) $(KERNEL_BIN) > $@
 
 run-img: $(IMG)
-	qemu-system-i386 -drive format=raw,file=$(IMG)
+>qemu-system-i386 -drive format=raw,file=$(IMG)
 
 clean:
-	rm -f $(BOOT_BIN) kernel_entry.o kernel.o kernel.elf $(KERNEL_BIN) $(IMG)
+>rm -f $(BOOT_BIN) kernel_entry.o kernel.o kernel.elf $(KERNEL_BIN) $(IMG)
 
 .PHONY: all clean run-img

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -1,0 +1,69 @@
+; boot.asm - Phase 2 bootloader for AikyaOS
+BITS 16
+ORG 0x7C00
+
+KERNEL_SECTORS equ 20           ; number of sectors to load
+
+start:
+    cli
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7C00
+
+    mov [boot_drive], dl       ; save boot drive
+
+    ; -------------------------------
+    ; Read kernel from disk to 0x1000
+    ; -------------------------------
+    mov bx, 0x1000             ; destination address
+    mov ah, 0x02               ; BIOS read function
+    mov al, KERNEL_SECTORS
+    mov ch, 0                  ; cylinder
+    mov cl, 2                  ; sector (kernel starts at sector 2)
+    mov dh, 0                  ; head
+    mov dl, [boot_drive]
+    int 0x13
+    jc disk_error
+
+    ; -------------------------------
+    ; Setup GDT and enter protected mode
+    ; -------------------------------
+
+gdt_start:
+gdt_null:   dq 0
+gdt_code:   dq 0x00CF9A000000FFFF
+gdt_data:   dq 0x00CF92000000FFFF
+gdt_end:
+
+gdt_descriptor:
+    dw gdt_end - gdt_start - 1
+    dd gdt_start
+
+    lgdt [gdt_descriptor]
+    mov eax, cr0
+    or eax, 1
+    mov cr0, eax
+    jmp 0x08:pmode_entry
+
+[BITS 32]
+pmode_entry:
+    mov ax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+    mov esp, 0x90000
+
+    jmp 0x08:0x1000            ; jump to loaded kernel
+
+disk_error:
+    hlt
+    jmp disk_error
+
+boot_drive: db 0
+
+times 510-($-$$) db 0
+dw 0xAA55

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -2,7 +2,9 @@
 BITS 16
 ORG 0x7C00
 
-KERNEL_SECTORS equ 20           ; number of sectors to load
+%ifndef KERNEL_SECTORS
+%error "KERNEL_SECTORS must be defined by the build system"
+%endif
 
 start:
     cli

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# AikyaOS Phase 1 Architecture
+# AikyaOS Phase 2 Architecture
 
 AikyaOS begins as a minimal hybrid microkernel. Only the core services – task
 scheduling, basic interrupt dispatch and a text console – live inside the
@@ -11,8 +11,8 @@ phases and communicate through an IPC mechanism.
 2. The boot sector loads the kernel image located in the following sectors
    into memory at 0x1000 and switches the CPU to 32‑bit protected mode.
 3. Control jumps to the kernel entry point where the C runtime starts.
-4. The kernel sets up its own GDT and an empty IDT, clears the screen and
-   prints a boot message.
+4. The 32-bit entry stub sets up a stack and calls into the C kernel.
+5. The kernel initializes the VGA text console and prints a boot message.
 
 ## Memory Map
 
@@ -20,6 +20,7 @@ phases and communicate through an IPC mechanism.
 0x00000000 - 0x000003FF : Real mode IVT
 0x00007C00 - 0x00007DFF : Boot sector
 0x00001000 - 0x00008FFF : Loaded kernel image
+0x00090000 - 0x00090FFF : Temporary stack
 0x000B8000 - 0x000B8FFF : VGA text buffer
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,33 @@
+# AikyaOS Phase 1 Architecture
+
+AikyaOS begins as a minimal hybrid microkernel. Only the core services – task
+scheduling, basic interrupt dispatch and a text console – live inside the
+kernel. Device drivers and system servers will run in user mode in later
+phases and communicate through an IPC mechanism.
+
+## Boot Flow
+
+1. The BIOS loads the 512 byte boot sector (`boot/boot.asm`) to 0x7C00.
+2. The boot sector loads the kernel image located in the following sectors
+   into memory at 0x1000 and switches the CPU to 32‑bit protected mode.
+3. Control jumps to the kernel entry point where the C runtime starts.
+4. The kernel sets up its own GDT and an empty IDT, clears the screen and
+   prints a boot message.
+
+## Memory Map
+
+```
+0x00000000 - 0x000003FF : Real mode IVT
+0x00007C00 - 0x00007DFF : Boot sector
+0x00001000 - 0x00008FFF : Loaded kernel image
+0x000B8000 - 0x000B8FFF : VGA text buffer
+```
+
+The kernel currently runs in identity mapped low memory. A higher half
+layout and paging will be introduced in later phases.
+
+## Future Work
+
+- Scheduler, IPC and user mode drivers.
+- Paging and virtual memory separation.
+- Filesystem and user programs.

--- a/kernel/entry.asm
+++ b/kernel/entry.asm
@@ -1,0 +1,18 @@
+; entry.asm - 32-bit kernel entry for AikyaOS
+BITS 32
+GLOBAL _start
+EXTERN kmain
+
+SECTION .text
+_start:
+    mov esp, stack_top      ; set up stack
+    call kmain              ; jump into C kernel
+.hang:
+    hlt
+    jmp .hang
+
+SECTION .bss
+align 16
+stack_bottom:
+    resb 4096               ; 4 KiB stack
+stack_top:

--- a/kernel/entry.asm
+++ b/kernel/entry.asm
@@ -16,3 +16,4 @@ align 16
 stack_bottom:
     resb 4096               ; 4 KiB stack
 stack_top:
+

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+
+typedef uint32_t size_t;
+
+static uint16_t *const VGA_BUFFER = (uint16_t *)0xB8000;
+static const uint8_t WHITE_ON_BLACK = 0x0F;
+
+void kmain(void) {
+    const char *msg = "AikyaOS Kernel Phase 2 Running in Protected Mode";
+    for (size_t i = 0; msg[i]; ++i) {
+        VGA_BUFFER[i] = ((uint16_t)msg[i]) | ((uint16_t)WHITE_ON_BLACK << 8);
+    }
+    for (;;) {
+        __asm__ volatile("hlt");
+    }
+}

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -1,8 +1,7 @@
 #include <stdint.h>
+#include <stddef.h>
 
-typedef uint32_t size_t;
-
-static uint16_t *const VGA_BUFFER = (uint16_t *)0xB8000;
+static volatile uint16_t *const VGA_BUFFER = (uint16_t *)0xB8000;
 static const uint8_t WHITE_ON_BLACK = 0x0F;
 
 void kmain(void) {

--- a/linker.ld
+++ b/linker.ld
@@ -1,0 +1,10 @@
+ENTRY(_start)
+SECTIONS
+{
+    . = 0x1000;
+
+    .text ALIGN(4096) : { *(.text*) }
+    .rodata ALIGN(4096) : { *(.rodata*) }
+    .data ALIGN(4096) : { *(.data*) }
+    .bss ALIGN(4096) : { *(.bss*) *(COMMON) }
+}


### PR DESCRIPTION
## Summary
- load kernel at 0x1000 and switch to protected mode
- set up a 32-bit entry stub and minimal C kernel that prints to VGA text mode
- provide linker script and Makefile to build and run a bootable image

## Testing
- `make clean`
- `make` *(fails: i686-elf-gcc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68909b64f2708330aaf17f7a5c96abd1